### PR TITLE
fix typo of #undef ADVANCE_TOKEN

### DIFF
--- a/picohttpparser/picohttpparser.c
+++ b/picohttpparser/picohttpparser.c
@@ -163,4 +163,4 @@ int phr_parse_request(const char* _buf, size_t len, const char** method,
 
 #undef CHECK_EOF
 #undef EXPECT
-#undef ADVACE_TOKEN
+#undef ADVANCE_TOKEN


### PR DESCRIPTION
easy typo of `#undef`.
